### PR TITLE
Remove Javascript from innerHtml of h2

### DIFF
--- a/captchaBox.html
+++ b/captchaBox.html
@@ -12,7 +12,7 @@
 
   <body class="body">
   <h1 class="box-heading">Debug this code to verify you're a human dev!</h1>
-  <h2 class="box-heading" id="language-name"></h2>
+  <h2 class="box-heading" id="language-name">Loading...</h2>
   <form class="box">
         <textarea id="captchaCode" cols="50" rows="25" placeholder="Code goes here"></textarea>
         <p id="errorMessg"></p>

--- a/captchaBox.html
+++ b/captchaBox.html
@@ -12,7 +12,7 @@
 
   <body class="body">
   <h1 class="box-heading">Debug this code to verify you're a human dev!</h1>
-  <h2 class="box-heading" id="language-name">JavaScript</h2>
+  <h2 class="box-heading" id="language-name"></h2>
   <form class="box">
         <textarea id="captchaCode" cols="50" rows="25" placeholder="Code goes here"></textarea>
         <p id="errorMessg"></p>


### PR DESCRIPTION
Please note that captchabox.js file has a SEPARATE list containing the name of the language which is rendered inside the h2 tag and there is no need to hard-code it in the h2 tag.